### PR TITLE
Added setting of proxyByPass in HttpConnector constructor then any no proxy host is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- HttpConnector now automatically enables proxyByPass for internal addresses then any "no proxy" host is set
+
 ## [7.2.0 - 2020-05-07]
 ###Added
 - Following redirects can now be configured

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>common-http</artifactId>
-    <version>7.2.1-SNAPSHOT</version>
+    <version>7.3.0-SNAPSHOT</version>
 
     <name>Samply Common Http library</name>
     <description>LIB to easily use both apache and jersey http connectors</description>

--- a/src/main/java/de/samply/common/http/HttpConnector.java
+++ b/src/main/java/de/samply/common/http/HttpConnector.java
@@ -354,9 +354,12 @@ public class HttpConnector {
         httpsProxyUsername = config.getProxy().getHttps().getUsername();
         httpsProxyPassword = config.getProxy().getHttps().getPassword();
       }
-    }
 
-    // TODO: handle bypassproxy switch in combination with noproxyhost setting from common config
+      if (config.getProxy().getNoProxyHosts() != null
+          && !config.getProxy().getNoProxyHosts().getHost().isEmpty()) {
+        bypassProxyForPrivateNetworks = true;
+      }
+    }
 
     credentialsProvider = initializeCredentialsProvider();
     initClients(followRedirects);
@@ -379,8 +382,9 @@ public class HttpConnector {
     httpsProxyUsername = config.getHttps().getUsername();
     httpsProxyPassword = config.getHttps().getPassword();
 
-    // TODO: handle bypassproxy switch in combination with noproxyhost setting from common config
-
+    if (config.getNoProxyHosts() != null && !config.getNoProxyHosts().getHost().isEmpty()) {
+      bypassProxyForPrivateNetworks = true;
+    }
     credentialsProvider = initializeCredentialsProvider();
     initClients();
   }


### PR DESCRIPTION
**What's in the PR**
* The proxyByPass configuration in a HttpConnector instance is automatically set to true, if the configuration contains any non-proxy host.
