### PR TITLE
Added support for newer Jersey version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - HttpConnector now automatically enables proxyByPass for internal addresses then any "no proxy" host is set
+- Support for Jersey 2.X. common-http can now generate both, Jersey 1.X and Jersey 2.X Clients based on the Apache HttpClient.
 
 ## [7.2.0 - 2020-05-07]
 ###Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ UNMERGED BRANCH -CHANGES FROM OTHER SAMPLY TEAMS MISSING
 LIB to easily use both apache and jersey http connectory
 
 ## Usage
-```
+### Configuration
+``` Java
 // define proxy if you have one (you can also use apache configuration instead of map)
 HashMap<String, String> config = new HashMap<>();
 config.put(HttpConnector.PROXY_HTTP_HOST, "123.123.123.123");
@@ -17,16 +18,17 @@ config.put(HttpConnector.PROXY_HTTP_PASSWORD, "bar");
 HttpConnector hc = new HttpConnector(config);
 ```
 
-```
+### Executing Requests
+``` Java
 // Add http-auth credentials
 hc.addHttpAuth("http://someserver.somedomain.de", "foo", "bar");
 ```
-```
+``` Java
 // Define headers
 HashMap<String, String> headers = new HashMap<String, String>();
 headers.put("Accept", "application/xml");
 ```
-```
+``` Java
 // Do some action, here: GET from a given url with set headers
 // if you want a CloseableHttpResponse instead, just call doAction instead
 HashMap<String, Object> ret = hc.doActionHashMap(
@@ -37,14 +39,24 @@ HashMap<String, Object> ret = hc.doActionHashMap(
 System.out.println("SC = " + ret.get("statuscode"));
 System.out.println("Body = " + ret.get("body"));
 ```
+### Generating a Http Client
+#### Apache HttpClient
+``` Java
+// to get a prepared ApacheHTTP ClosableHttpClient for a certain url
+org.apache.http.impl.client.CloseableHttpClient apacheClient = hc.getHttpClient("http://osse-register.de");
 ```
+
+#### Jersey 1.X
+Jersey is a Java Library specifically for REST. So this client is more a REST Client than a http client.
+``` Java
 // To get a prepared Jersey client for a certain url
 com.sun.jersey.api.client.Client jerseyClient = hc.getJerseyClient("http://osse-register.de", false);
 ```
 
-```
-// to get a prepared ApacheHTTP ClosableHttpClient for a certain url
-org.apache.http.impl.client.CloseableHttpClient apacheClient = hc.getHttpClient("http://osse-register.de");
+#### Jersey 2.X
+Jersey 2 complies to the JAX-RS interface. So the client generated is from the JAX-RS interface.
+``` Java
+javax.ws.rs.client.Client client = hc.getJaxRsClient("http://osse-register.de");
 ```
 
 ## Build
@@ -55,7 +67,7 @@ Use maven to build the jar:
 mvn clean install
 ```
 
- ## License
+## License
         
  Copyright 2020 The Samply Development Community
         

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,29 @@
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <httpclient.version>4.5.3</httpclient.version>
     </properties>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>2.32</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <!-- outdated Jersey-Version but it is hard to upgrade to 2.x -->
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
             <version>${version.jersey}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
@@ -75,6 +91,23 @@
             <groupId>com.sun.jersey.contribs</groupId>
             <artifactId>jersey-apache-client4</artifactId>
             <version>${version.jersey}</version>
+        </dependency>
+        <!-- Supply jersey 2.x parallel to jersey 1.x -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
**What's in the PR**
* Added Jersey Client from Jersey Bom 2.38
* New Methods to create a JAX-RS Client based on Jersey 2.xx. The client uses the HttpClient from the apache lib as intentioned by  common-http.
