### PR TITLE
Added automatic push of maven artifacts on master and develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
     - name: Checkout Sourcecode
       uses: actions/checkout@v2
+
     - name: Setup Java for publishing to Maven Central
       uses: actions/setup-java@v2
       with:
         java-version: 8
-        distribution: 'adopt'
+        distribution: 'temurin'
         server-id: ossrh
         # environment variables that will contain osshr sonatype jira user and password then mvn deploy is executed
         server-username: MAVEN_USERNAME
@@ -27,8 +29,10 @@ jobs:
         gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }} # Value of the GPG private key to import
         # environment variable that will contain the passphrase for gpg-private-key then mvn deploy is executed
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
     - name: Run the unit tests
       run: mvn --batch-mode test
+
     - name: Publish package
       run: |
         mvn --batch-mode -Dgpg.passphrase=$MAVEN_GPG_PASSPHRASE deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@
 
 name: Java CI with Maven
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["master", "develop", "feature/automaticDeployment"]
 
 jobs:
   build:
@@ -11,12 +13,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Setup Java
-      uses: actions/setup-java@v1
+    - name: Checkout Sourcecode
+      uses: actions/checkout@v2
+    - name: Setup Java for publishing to Maven Central
+      uses: actions/setup-java@v2
       with:
         java-version: 8
-
-    - name: Build with Maven
-      run: mvn -B package
+        distribution: 'adopt'
+        server-id: ossrh
+        # environment variables that will contain osshr sonatype jira user and password then mvn deploy is executed
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }} # Value of the GPG private key to import
+        # environment variable that will contain the passphrase for gpg-private-key then mvn deploy is executed
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+    - name: Run the unit tests
+      run: mvn --batch-mode test
+    - name: Publish package
+      run: |
+        mvn --batch-mode -Dgpg.passphrase=$MAVEN_GPG_PASSPHRASE deploy
+      env:
+        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - HttpConnector now automatically enables proxyByPass for internal addresses then any "no proxy" host is set
+- Automated deploy to maven central for develop and master
 
 ## [7.2.0 - 2020-05-07]
-###Added
+### Added
 - Following redirects can now be configured
 
 ## [7.1.1 - 2020-10-29]
-###Changed
+### Changed
 - Google Style Code
 
 ## [7.1.0 - 2020-10-29]
-###Added
+### Added
 - Github Actions
 
 ## [7.0.0 - 2020-10-29]

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,32 @@
         <httpclient.version>4.5.3</httpclient.version>
     </properties>
 
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${maven-gpg-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>deploy</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+              <configuration>
+                <!-- Prevent `gpg` from using pinentry programs -->
+                <gpgArguments>
+                  <arg>--pinentry-mode</arg>
+                  <arg>loopback</arg>
+                </gpgArguments>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+
     <dependencies>
         <!-- outdated Jersey-Version but it is hard to upgrade to 2.x -->
         <dependency>


### PR DESCRIPTION
**What's in the PR**
* extension of the ci workflow for signing and deploying the maven artifact

You can view the automatically created artifacts at [oss.sonatype.org](https://oss.sonatype.org/index.html#view-repositories;snapshots~browsestorage~/de/samply/common-http/7.3.0-SNAPSHOT/common-http-7.3.0-20210824.112749-1.jar).
Currently the files are signed with my account. I would try to create a bot account at sonatype for samply.

** Please Note **
* changes to the pom.xml should be pushed to samply parent. I will create a PR and link it.
